### PR TITLE
Update README.md `getArticle` method example

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ fetch(url).then((res) => {
 }).then((html) => {
   let content = ArticleParser.getArticle(html);
   return content;
+})
+.then((article) => {
+  console.log(article);
+})
+.catch((err) => {
+  console.log(err);
 });
 ```
 


### PR DESCRIPTION
`getArticle` method returns `Promise` instead of html string.
So, the example is a bit confusing. :)