### PR TITLE
Allow empty tags in setSanitizeHtmlOptions allowedTags

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -67,7 +67,7 @@ export const setNodeFetchOptions = (opts) => {
 
 export const setSanitizeHtmlOptions = (opts) => {
   copies(opts, sanitizeHtmlOptions);
-  if (opts.allowedTags && opts.allowedTags.length > 0) {
+  if (Array.isArray(opts.allowedTags)) {
     sanitizeHtmlOptions.allowedTags = [...opts.allowedTags];
   }
 };

--- a/tests/specs/main.js
+++ b/tests/specs/main.js
@@ -261,5 +261,15 @@ test('Testing setSanitizeHtmlOptions/getSanitizeHtmlOptions methods', (assert) =
     'getSanitizeHtmlOptions() must work correctly'
   );
 
+  setSanitizeHtmlOptions({
+    allowedTags: [],
+  });
+
+  assert.same(
+    getSanitizeHtmlOptions().allowedTags,
+    [],
+    'getSanitizeHtmlOptions() accepts empty tags'
+  );
+
   assert.end();
 });


### PR DESCRIPTION
Awesome library! thanks for your hard work. I am trying to get pure txt from the articles with this option:
https://www.npmjs.com/package/sanitize-html#what-if-i-dont-want-to-allow-any-tags


