### PR TITLE
Fixes htmlparser2 module error

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "cheerio": "^1.0.0-rc.3",
     "debug": "^4.2.0",
     "html-minifier": "^4.0.0",
+    "htmlparser2": "^6.0.0",
     "node-fetch": "^2.6.1",
     "oembed-parser": "^1.4.2",
     "readabilitySAX": "^1.6.1",

--- a/src/utils/extractWithReadability.js
+++ b/src/utils/extractWithReadability.js
@@ -1,7 +1,7 @@
 // utils/extractWithReadability
 
 const {Readability} = require('readabilitySAX');
-const Parser = require('htmlparser2/lib/Parser.js');
+const {Parser} = require('htmlparser2');
 
 module.exports = async (html) => {
   const readable = new Readability();

--- a/src/utils/extractWithReadability.test.js
+++ b/src/utils/extractWithReadability.test.js
@@ -1,16 +1,10 @@
 // extractWithReadability.test
 
+const {readFileSync} = require('fs');
 
-const {
-  readFileSync,
-} = require('fs');
-
-const {
-  isString,
-} = require('bellajs');
+const {isString} = require('bellajs');
 
 const extractWithReadability = require('./extractWithReadability');
-
 
 test(`test extractWithReadability from good html content`, async () => {
   const html = readFileSync('./test-data/venturebeat.txt', 'utf8');
@@ -18,7 +12,6 @@ test(`test extractWithReadability from good html content`, async () => {
   expect(isString(result)).toBe(true);
   expect(result.length > 200).toBe(true);
 });
-
 
 test(`test extractWithReadability from bad html content`, async () => {
   const result = await extractWithReadability(null);


### PR DESCRIPTION
PR fixes htmlparser2 module error because [Issue](https://github.com/ndaidong/article-parser/issues/139)

- htmlparser2 was missing from dependancy
- util function was using deprecated version of htmlparser2