### PR TITLE
fix something for es6

### DIFF
--- a/build.js
+++ b/build.js
@@ -22,15 +22,16 @@ const comment = [
 ].join(' - ')
 
 /**
- * @type import(’esbuild‘).BuildOptions
- */
+ * @type {import('esbuild').BuildOptions}
+ * */
 const baseOpt = {
   entryPoints: ['src/main.js'],
   bundle: true,
   charset: 'utf8',
   target: ['es2020', 'node14'],
-  minify: false,
-  write: true
+  minify: true,
+  write: true,
+  sourcemap: 'external'
 }
 
 /**

--- a/build.js
+++ b/build.js
@@ -46,7 +46,7 @@ const cjsVersion = {
   banner: {
     js: comment
   },
-  external: ['*.node', './xhr-sync-worker.js']
+  external: ['canvas', '*.node', './xhr-sync-worker.js']
 }
 buildSync(cjsVersion)
 

--- a/build.js
+++ b/build.js
@@ -1,17 +1,18 @@
 /**
  * build.js
  * @ndaidong
-**/
-
-import { readFileSync, writeFileSync } from 'fs'
-import { execSync } from 'child_process'
+ **/
+import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'fs'
 
 import { buildSync } from 'esbuild'
 
-const pkg = JSON.parse(readFileSync('./package.json'))
+const pkg = JSON.parse(readFileSync('./package.json', { encoding: 'utf-8' }))
 
-execSync('rm -rf dist')
-execSync('mkdir dist')
+rmSync('dist', {
+  force: true,
+  recursive: true
+})
+mkdirSync('dist')
 
 const buildTime = (new Date()).toISOString()
 const comment = [
@@ -20,6 +21,9 @@ const comment = [
   `published under ${pkg.license} license`
 ].join(' - ')
 
+/**
+ * @type import(’esbuild‘).BuildOptions
+ */
 const baseOpt = {
   entryPoints: ['src/main.js'],
   bundle: true,
@@ -29,6 +33,9 @@ const baseOpt = {
   write: true
 }
 
+/**
+ * @type {import('esbuild').BuildOptions}
+ */
 const cjsVersion = {
   ...baseOpt,
   platform: 'node',
@@ -37,7 +44,8 @@ const cjsVersion = {
   outfile: `dist/cjs/${pkg.name}.js`,
   banner: {
     js: comment
-  }
+  },
+  external: ['*.node', './xhr-sync-worker.js']
 }
 buildSync(cjsVersion)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,21 @@
 // Type definitions
 
+export interface QueryRule {
+    patterns: Array<RegExp>,
+    unwanted?: Array<String>,
+    slector?: String
+}
+
 export function extract(url: string): Promise<ArticleData>;
 
 export function setParserOptions(props: object): void;
-export function setNodeFetchOptions(props: object): void;
+export function setRequestOptions(props: object): void;
 export function setSanitizeHtmlOptions(props: object): void;
+export function addQueryRules(entries: Array<QueryRule>): Number;
 
 export function getParserOptions(): object;
-export function getNodeFetchOptions(): object;
+export function getRequestOptions(): object;
 export function getSanitizeHtmlOptions(): object;
-
 
 export interface ArticleData {
     url?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@
 export interface QueryRule {
     patterns: Array<RegExp>,
     unwanted?: Array<String>,
-    slector?: String
+    selector?: String
 }
 
 export function extract(url: string): Promise<ArticleData>;

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 /**
  * Starting app
  * @ndaidong
-**/
+ **/
 
-const main = require('./src/main')
-main.version = require('./package.json').version
+import metadata from './package.json'
 
-module.exports = main
+export * from './src/main'
+export const version = metadata.version

--- a/package.json
+++ b/package.json
@@ -25,14 +25,14 @@
   },
   "dependencies": {
     "@mozilla/readability": "^0.4.1",
-    "axios": "^0.24.0",
+    "axios": "^0.25.0",
     "bellajs": "^11.0.0rc3",
     "cheerio": "^1.0.0-rc.10",
     "cross-env": "^7.0.3",
     "debug": "^4.3.3",
-    "html-minifier-terser": "^6.1.0",
+    "html-minifier-terser": "^7.0.0-alpha.1",
     "jsdom": "^19.0.0",
-    "sanitize-html": "^2.6.1",
+    "sanitize-html": "^2.7.0",
     "string-comparison": "^1.0.9"
   },
   "babel": {
@@ -50,10 +50,10 @@
     ]
   },
   "devDependencies": {
-    "@babel/plugin-transform-modules-commonjs": "^7.16.7",
-    "esbuild": "^0.14.10",
-    "jest": "^27.4.7",
-    "nock": "^13.2.1",
+    "@babel/plugin-transform-modules-commonjs": "^7.16.8",
+    "esbuild": "^0.14.18",
+    "jest": "^27.5.0",
+    "nock": "^13.2.4",
     "standard": "^16.0.4"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "node": ">= 14"
   },
   "scripts": {
-    "lint": "standard .",
+    "lint": "npx standard .",
     "pretest": "npm run lint",
-    "test": "NODE_ENV=test jest --verbose --coverage=true --unhandled-rejections=strict --detectOpenHandles",
+    "test": "cross-env NODE_ENV=test jest --verbose --coverage=true --unhandled-rejections=strict --detectOpenHandles",
     "build": "node build src/main.js",
-    "eval": "DEBUG=*:* node eval",
+    "eval": "cross-env DEBUG=*:* node eval",
     "reset": "node reset"
   },
   "dependencies": {
@@ -28,6 +28,7 @@
     "axios": "^0.24.0",
     "bellajs": "^11.0.0rc3",
     "cheerio": "^1.0.0-rc.10",
+    "cross-env": "^7.0.3",
     "debug": "^4.3.3",
     "html-minifier-terser": "^6.1.0",
     "jsdom": "^19.0.0",
@@ -52,7 +53,8 @@
     "@babel/plugin-transform-modules-commonjs": "^7.16.7",
     "esbuild": "^0.14.10",
     "jest": "^27.4.7",
-    "nock": "^13.2.1"
+    "nock": "^13.2.1",
+    "standard": "^16.0.4"
   },
   "keywords": [
     "article",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "npx standard .",
     "pretest": "npm run lint",
     "test": "cross-env NODE_ENV=test jest --verbose --coverage=true --unhandled-rejections=strict --detectOpenHandles",
-    "build": "node build src/main.js",
+    "build": "node build",
     "eval": "cross-env DEBUG=*:* node eval",
     "reset": "node reset"
   },


### PR DESCRIPTION
Should fix #206 
- Cheery pick the 313bd73
- Fix a typo
- Needless to install standard globally
- `cross-env` for test on Windows
- Build
	- mark `*.node` and `./xhr-sync-worker.js` as external
	- use `fs` for file operate
    - add type for config
 