### PR TITLE
feat: replace jsdom with linkedom which is "lighter"

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "scripts": {
     "lint": "standard .",
     "pretest": "npm run lint",
-    "test": "NODE_ENV=test jest --verbose --coverage=true --unhandled-rejections=strict --detectOpenHandles --forceExit",
-    "eval": "DEBUG=*:* node eval",
+    "test": "cross-env NODE_ENV=test jest --verbose --coverage=true --unhandled-rejections=strict --detectOpenHandles --forceExit",
+    "eval": "cross-env DEBUG=*:* node eval",
     "reset": "node reset"
   },
   "dependencies": {
@@ -27,13 +27,15 @@
     "cheerio": "^1.0.0-rc.10",
     "debug": "^4.3.3",
     "html-minifier-terser": "^6.1.0",
-    "jsdom": "^19.0.0",
+    "linkedom": "^0.14.0",
     "sanitize-html": "^2.6.1",
     "string-comparison": "^1.0.9"
   },
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "jest": "^27.4.7",
-    "nock": "^13.2.2"
+    "nock": "^13.2.2",
+    "standard": "^16.0.4"
   },
   "keywords": [
     "article",

--- a/src/utils/extractWithReadability.js
+++ b/src/utils/extractWithReadability.js
@@ -1,11 +1,13 @@
 // utils/extractWithReadability
 
 const { Readability } = require('@mozilla/readability')
-const { JSDOM } = require('jsdom')
+const { DOMParser } = require('linkedom')
+const { isString } = require('bellajs')
 
-module.exports = (html, url) => {
-  const doc = new JSDOM(html, { url })
-  const reader = new Readability(doc.window.document)
+module.exports = (html) => {
+  if (!isString(html)) return null
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  const reader = new Readability(doc)
   const result = reader.parse() || {}
   const { content, textContent, length } = result
   return !textContent || length < 60 ? null : content


### PR DESCRIPTION
In this project, we only use the DOM API. Quote from [linkedom](https://github.com/WebReflection/linkedom#faq):
> implement features not interesting for Server Side Rendering. If you need to pretend your NodeJS, Worker, or any other environment, is a browser, please [use JSDOM](https://github.com/jsdom/jsdom)

JSDOM has a lot of work that is unnecessary for this project, adding complexity to dependencies and slowing down operations.